### PR TITLE
Use the Pebble Account Token for the GA User ID.

### DIFF
--- a/src/js/pebble-ga.js
+++ b/src/js/pebble-ga.js
@@ -2,7 +2,7 @@ var Analytics = function(analyticsId, appName, appVersion) {
   this.analyticsId = analyticsId;
   this.appName = appName;
   this.appVersion = appVersion;
-  this.analyticsUserId = Math.round(Math.random() * 10000000);
+  this.analyticsUserId = Pebble.getAccountToken();
 }
 
 Analytics.prototype._trackGA = function(type, params) {


### PR DESCRIPTION
By using the value of Pebble.getAccountToken() for the user ID we can now track users across multiple runs of the app.
